### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,6 @@
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Kellojo/Offline-Docs/security/code-scanning/1](https://github.com/Kellojo/Offline-Docs/security/code-scanning/1)

To fix the problem, set an explicit `permissions:` block to enforce the principle of least privilege for the `GITHUB_TOKEN`. This can be done at the workflow root (applying to all jobs), or for each job separately to allow per-job minimum privilege. The best solution here, given job tasks, is:
- Most jobs (like the `build` job) only require `contents: read` to check out the code and run build/test.
- The `publish-npm` job needs to publish to npm via `NODE_AUTH_TOKEN`, but unless it's using the GITHUB_TOKEN to push to the repository (e.g., create tags or releases), `contents: read` suffices. However, if you ever use GITHUB_TOKEN to do things like publish a release, you'd want more perms there.
- Since the provided workflow does not show any steps that use the GITHUB_TOKEN for writing, granting only `contents: read` at the workflow root is the minimum and safest fix, and sufficient for these jobs.

Therefore, add at the top (after the `name:` line) of `.github/workflows/npm-publish.yml`:
```yaml
permissions:
  contents: read
```

No other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
