### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Kellojo/Offline-Docs/security/code-scanning/9](https://github.com/Kellojo/Offline-Docs/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. The block should limit the inherited permissions for the `GITHUB_TOKEN` to the minimum required by the workflow. In this case, as the workflow only checks out code, builds, and runs tests, setting `contents: read` at the workflow root is appropriate. Edit the `.github/workflows/Tests.yml` file to add the following YAML block after the `name: Tests` line (i.e., before the `on:` block):

```yaml
permissions:
  contents: read
```

No imports or code changes are necessary elsewhere, as this is a pure configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
